### PR TITLE
Revert "qcacld-3.0: Add bound check for fixed_param->total_num_tx_pow…

### DIFF
--- a/drivers/staging/qcacld-3.0/core/wma/src/wma_utils.c
+++ b/drivers/staging/qcacld-3.0/core/wma/src/wma_utils.c
@@ -1544,14 +1544,6 @@ static int wma_unified_radio_tx_power_level_stats_event_handler(void *handle,
 							 fixed_param->radio_id;
 	tx_power_level_values = (uint8_t *) param_tlvs->tx_time_per_power_level;
 
-	if (fixed_param->total_num_tx_power_levels >
-		rs_results->total_num_tx_power_levels) {
-		WMA_LOGE("%s: excess tx_power buffers:%d, total_num_tx_power_levels:%d",
-			 __func__, fixed_param->total_num_tx_power_levels,
-			 rs_results->total_num_tx_power_levels);
-		return -EINVAL;
-	}
-
 	rs_results->total_num_tx_power_levels =
 				fixed_param->total_num_tx_power_levels;
 	if (!rs_results->total_num_tx_power_levels) {


### PR DESCRIPTION
…er_levels"

* for some reasons wifi hal went crazy after this
* asssuming caf hal might have it fixed, but reverting for aosp compatibility

This reverts commit a01623699ad76fc6947483b063727f417d526df7.

Change-Id: Ic133a9680cd5d6867bca999067046b44ebb5e93f
Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>